### PR TITLE
修正CIMServer可能的NPE问题

### DIFF
--- a/cim-server/src/main/java/com/crossoverjie/cim/server/server/CIMServer.java
+++ b/cim-server/src/main/java/com/crossoverjie/cim/server/server/CIMServer.java
@@ -86,6 +86,7 @@ public class CIMServer {
 
         if (null == socketChannel) {
             LOGGER.error("client {} offline!", sendMsgReqVO.getUserId());
+            return;
         }
         CIMRequestProto.CIMReqProtocol protocol = CIMRequestProto.CIMReqProtocol.newBuilder()
                 .setRequestId(sendMsgReqVO.getUserId())


### PR DESCRIPTION
socketChannel为null时，可能触发NPE。