### PR TITLE
feature:support offline atomic command by lua

### DIFF
--- a/cim-forward-route/src/main/java/com/crossoverjie/cim/route/service/UserInfoCacheService.java
+++ b/cim-forward-route/src/main/java/com/crossoverjie/cim/route/service/UserInfoCacheService.java
@@ -30,13 +30,6 @@ public interface UserInfoCacheService {
     boolean saveAndCheckUserLoginStatus(Long userId) throws Exception ;
 
     /**
-     * 清除用户的登录状态
-     * @param userId
-     */
-    void removeLoginStatus(Long userId) ;
-
-
-    /**
      * query all online user
      * @return online user
      */

--- a/cim-forward-route/src/main/java/com/crossoverjie/cim/route/service/impl/AccountServiceRedisImpl.java
+++ b/cim-forward-route/src/main/java/com/crossoverjie/cim/route/service/impl/AccountServiceRedisImpl.java
@@ -18,19 +18,22 @@ import lombok.extern.slf4j.Slf4j;
 import okhttp3.OkHttpClient;
 import okhttp3.Response;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.data.redis.connection.RedisConnection;
 import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.scripting.support.ResourceScriptSource;
 import org.springframework.stereotype.Service;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
 import static com.crossoverjie.cim.common.enums.StatusEnum.OFF_LINE;
-import static com.crossoverjie.cim.route.constant.Constant.ACCOUNT_PREFIX;
-import static com.crossoverjie.cim.route.constant.Constant.ROUTE_PREFIX;
+import static com.crossoverjie.cim.route.constant.Constant.*;
 
 /**
  * Function:
@@ -158,12 +161,12 @@ public class AccountServiceRedisImpl implements AccountService {
     @Override
     public void offLine(Long userId) {
 
-        // TODO: 2019-01-21 改为一个原子命令，以防数据一致性
+        DefaultRedisScript redisScript = new DefaultRedisScript();
+        redisScript.setScriptSource(new ResourceScriptSource(new ClassPathResource("lua/offLine.lua")));
 
-        //删除路由
-        redisTemplate.delete(ROUTE_PREFIX + userId);
-
-        //删除登录状态
-        userInfoCacheService.removeLoginStatus(userId);
+        redisTemplate.execute(redisScript,
+                Collections.singletonList(ROUTE_PREFIX + userId),
+                LOGIN_STATUS_PREFIX,
+                userId.toString());
     }
 }

--- a/cim-forward-route/src/main/java/com/crossoverjie/cim/route/service/impl/UserInfoCacheServiceImpl.java
+++ b/cim-forward-route/src/main/java/com/crossoverjie/cim/route/service/impl/UserInfoCacheServiceImpl.java
@@ -64,11 +64,6 @@ public class UserInfoCacheServiceImpl implements UserInfoCacheService {
     }
 
     @Override
-    public void removeLoginStatus(Long userId) {
-        redisTemplate.opsForSet().remove(LOGIN_STATUS_PREFIX,userId.toString()) ;
-    }
-
-    @Override
     public Set<CIMUserInfo> onlineUser() {
         Set<CIMUserInfo> set = null ;
         Set<String> members = redisTemplate.opsForSet().members(LOGIN_STATUS_PREFIX);

--- a/cim-forward-route/src/main/resources/lua/offLine.lua
+++ b/cim-forward-route/src/main/resources/lua/offLine.lua
@@ -1,0 +1,5 @@
+
+redis.call('DEL', KEYS[1])
+
+redis.call('SREM', ARGV[1], ARGV[2])
+

--- a/cim-forward-route/src/test/java/com/crossoverjie/cim/route/service/impl/UserInfoCacheServiceImplTest.java
+++ b/cim-forward-route/src/test/java/com/crossoverjie/cim/route/service/impl/UserInfoCacheServiceImplTest.java
@@ -24,11 +24,6 @@ public class UserInfoCacheServiceImplTest extends AbstractBaseTest{
     }
 
     @Test
-    public void removeLoginStatus() throws Exception {
-        userInfoCacheService.removeLoginStatus(2000L);
-    }
-
-    @Test
     public void onlineUser(){
         Set<CIMUserInfo> cimUserInfos = userInfoCacheService.onlineUser();
         log.info("cimUserInfos={}", JSON.toJSONString(cimUserInfos));


### PR DESCRIPTION
In the previous code, I noticed that there are some todos that need improvement. May I make some enhancements to the todo regarding the '[AccountServiceRedisImpl.offLine](https://github.com/cmgyqjj/cim/blob/master/cim-forward-route/src/main/java/com/crossoverjie/cim/route/service/impl/AccountServiceRedisImpl.java)'? 

> 
    @Override
    public void offLine(Long userId) {

        // TODO: 2019-01-21 改为一个原子命令，以防数据一致性

        //删除路由
        redisTemplate.delete(ROUTE_PREFIX + userId);

        //删除登录状态
        userInfoCacheService.removeLoginStatus(userId);
    }

As for the two instances of Redis deletion, I suggest using Lua scripts to execute them, to prevent the scenario where the route is deleted but the data remains inconsistent due to still being logged in.
