### PR TITLE
feature:Use_Spring_IOC_to_refactor_RpcProxyManager

### DIFF
--- a/cim-forward-route/src/main/java/com/crossoverjie/cim/route/config/BeanConfig.java
+++ b/cim-forward-route/src/main/java/com/crossoverjie/cim/route/config/BeanConfig.java
@@ -10,6 +10,7 @@ import com.crossoverjie.cim.server.api.ServerApi;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import jakarta.annotation.Resource;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.OkHttpClient;
 import org.I0Itec.zkclient.ZkClient;
@@ -37,7 +38,7 @@ import java.util.concurrent.TimeUnit;
 public class BeanConfig {
 
 
-    @Autowired
+    @Resource
     private AppConfiguration appConfiguration;
 
 

--- a/cim-forward-route/src/main/java/com/crossoverjie/cim/route/config/BeanConfig.java
+++ b/cim-forward-route/src/main/java/com/crossoverjie/cim/route/config/BeanConfig.java
@@ -1,10 +1,12 @@
 package com.crossoverjie.cim.route.config;
 
+import com.crossoverjie.cim.common.core.proxy.RpcProxyManager;
 import com.crossoverjie.cim.common.metastore.MetaStore;
 import com.crossoverjie.cim.common.metastore.ZkConfiguration;
 import com.crossoverjie.cim.common.metastore.ZkMetaStoreImpl;
 import com.crossoverjie.cim.common.route.algorithm.RouteHandle;
 import com.crossoverjie.cim.common.route.algorithm.consistenthash.AbstractConsistentHash;
+import com.crossoverjie.cim.server.api.ServerApi;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -104,5 +106,10 @@ public class BeanConfig {
 
         }
 
+    }
+
+    @Bean
+    public ServerApi serverApi(OkHttpClient okHttpClient) {
+        return RpcProxyManager.create(ServerApi.class, okHttpClient);
     }
 }

--- a/cim-forward-route/src/main/java/com/crossoverjie/cim/route/service/impl/AccountServiceRedisImpl.java
+++ b/cim-forward-route/src/main/java/com/crossoverjie/cim/route/service/impl/AccountServiceRedisImpl.java
@@ -14,6 +14,7 @@ import com.crossoverjie.cim.route.service.AccountService;
 import com.crossoverjie.cim.route.service.UserInfoCacheService;
 import com.crossoverjie.cim.server.api.ServerApi;
 import com.crossoverjie.cim.server.api.vo.req.SendMsgReqVO;
+import jakarta.annotation.Resource;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.OkHttpClient;
 import okhttp3.Response;
@@ -46,16 +47,16 @@ import static com.crossoverjie.cim.route.constant.Constant.*;
 @Service
 public class AccountServiceRedisImpl implements AccountService {
 
-    @Autowired
+    @Resource
     private RedisTemplate<String, String> redisTemplate;
 
-    @Autowired
+    @Resource
     private UserInfoCacheService userInfoCacheService;
 
-    @Autowired
+    @Resource
     private OkHttpClient okHttpClient;
 
-    @Autowired
+    @Resource
     private ServerApi serverApi;
 
     @Override

--- a/cim-forward-route/src/main/java/com/crossoverjie/cim/route/service/impl/AccountServiceRedisImpl.java
+++ b/cim-forward-route/src/main/java/com/crossoverjie/cim/route/service/impl/AccountServiceRedisImpl.java
@@ -55,6 +55,9 @@ public class AccountServiceRedisImpl implements AccountService {
     @Autowired
     private OkHttpClient okHttpClient;
 
+    @Autowired
+    private ServerApi serverApi;
+
     @Override
     public RegisterInfoResVO register(RegisterInfoResVO info) {
         String key = ACCOUNT_PREFIX + info.getUserId();
@@ -153,7 +156,7 @@ public class AccountServiceRedisImpl implements AccountService {
         CIMUserInfo cimUserInfo = userInfoCacheService.loadUserInfoByUserId(sendUserId);
 
         String url = "http://" + cimServerResVO.getIp() + ":" + cimServerResVO.getHttpPort();
-        ServerApi serverApi = RpcProxyManager.create(ServerApi.class, okHttpClient);
+
         SendMsgReqVO vo = new SendMsgReqVO(cimUserInfo.getUserName() + ":" + groupReqVO.getMsg(), groupReqVO.getUserId());
         serverApi.sendMsg(vo, url);
     }

--- a/cim-server/src/main/java/com/crossoverjie/cim/server/config/BeanConfig.java
+++ b/cim-server/src/main/java/com/crossoverjie/cim/server/config/BeanConfig.java
@@ -1,10 +1,12 @@
 package com.crossoverjie.cim.server.config;
 
 import com.crossoverjie.cim.common.constant.Constants;
+import com.crossoverjie.cim.common.core.proxy.RpcProxyManager;
 import com.crossoverjie.cim.common.metastore.MetaStore;
 import com.crossoverjie.cim.common.metastore.ZkConfiguration;
 import com.crossoverjie.cim.common.metastore.ZkMetaStoreImpl;
 import com.crossoverjie.cim.common.protocol.CIMRequestProto;
+import com.crossoverjie.cim.route.api.RouteApi;
 import okhttp3.OkHttpClient;
 import org.I0Itec.zkclient.ZkClient;
 import org.apache.curator.retry.ExponentialBackoffRetry;
@@ -23,6 +25,9 @@ import java.util.concurrent.TimeUnit;
  */
 @Configuration
 public class BeanConfig {
+
+    @Autowired
+    private AppConfiguration appConfiguration;
 
     /**
      * http client
@@ -56,5 +61,10 @@ public class BeanConfig {
                 .setType(Constants.CommandType.PING)
                 .build();
         return heart;
+    }
+
+    @Bean
+    public RouteApi routeApi(OkHttpClient okHttpClient) {
+        return RpcProxyManager.create(RouteApi.class, appConfiguration.getRouteUrl(), okHttpClient);
     }
 }

--- a/cim-server/src/main/java/com/crossoverjie/cim/server/config/BeanConfig.java
+++ b/cim-server/src/main/java/com/crossoverjie/cim/server/config/BeanConfig.java
@@ -7,6 +7,7 @@ import com.crossoverjie.cim.common.metastore.ZkConfiguration;
 import com.crossoverjie.cim.common.metastore.ZkMetaStoreImpl;
 import com.crossoverjie.cim.common.protocol.CIMRequestProto;
 import com.crossoverjie.cim.route.api.RouteApi;
+import jakarta.annotation.Resource;
 import okhttp3.OkHttpClient;
 import org.I0Itec.zkclient.ZkClient;
 import org.apache.curator.retry.ExponentialBackoffRetry;
@@ -26,7 +27,7 @@ import java.util.concurrent.TimeUnit;
 @Configuration
 public class BeanConfig {
 
-    @Autowired
+    @Resource
     private AppConfiguration appConfiguration;
 
     /**

--- a/cim-server/src/main/java/com/crossoverjie/cim/server/kit/RouteHandler.java
+++ b/cim-server/src/main/java/com/crossoverjie/cim/server/kit/RouteHandler.java
@@ -32,6 +32,9 @@ public class RouteHandler {
     @Autowired
     private AppConfiguration configuration;
 
+    @Autowired
+    private RouteApi routeApi;
+
     /**
      * 用户下线
      *
@@ -57,7 +60,6 @@ public class RouteHandler {
      * @throws IOException
      */
     public void clearRouteInfo(CIMUserInfo userInfo) {
-        RouteApi routeApi = RpcProxyManager.create(RouteApi.class, configuration.getRouteUrl(), okHttpClient);
         ChatReqVO vo = new ChatReqVO(userInfo.getUserId(), userInfo.getUserName());
         routeApi.offLine(vo);
     }

--- a/cim-server/src/main/java/com/crossoverjie/cim/server/kit/RouteHandler.java
+++ b/cim-server/src/main/java/com/crossoverjie/cim/server/kit/RouteHandler.java
@@ -7,6 +7,7 @@ import com.crossoverjie.cim.route.api.vo.req.ChatReqVO;
 import com.crossoverjie.cim.server.config.AppConfiguration;
 import com.crossoverjie.cim.server.util.SessionSocketHolder;
 import io.netty.channel.socket.nio.NioSocketChannel;
+import jakarta.annotation.Resource;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.OkHttpClient;
 import okhttp3.Response;
@@ -26,13 +27,13 @@ import java.io.IOException;
 @Slf4j
 public class RouteHandler {
 
-    @Autowired
+    @Resource
     private OkHttpClient okHttpClient;
 
-    @Autowired
+    @Resource
     private AppConfiguration configuration;
 
-    @Autowired
+    @Resource
     private RouteApi routeApi;
 
     /**


### PR DESCRIPTION
For: Use Spring IOC to refactor RpcProxyManager [#135 ](https://github.com/crossoverJie/cim/issues/135)

In previous versions, RpcProxyManager would be repeatedly created. In this change, the `RpcProxyManager` is managed using the Spring Ioc approach to reuse objects.