### PR TITLE
.4062073974432528:2b540a6496f77031be06f3c603c490b5_69f60e668ca4bbb02334a2ee.69f610688ca4bbb02334a313.69f6106836ed5d0d89ea81b8:Trae CN.T(2026/5/2 22:55:36)

### DIFF
--- a/cim-client-sdk/src/main/java/com/crossoverjie/cim/client/sdk/Client.java
+++ b/cim-client-sdk/src/main/java/com/crossoverjie/cim/client/sdk/Client.java
@@ -28,6 +28,22 @@ public interface Client extends Closeable {
 
     CompletableFuture<Void> sendGroupAsync(String msg);
 
+    /**
+     * 发送消息已读回执
+     * @param msgId 消息ID
+     * @throws Exception
+     */
+    default void sendReadAck(long msgId) throws Exception {
+        sendReadAckAsync(msgId).get();
+    }
+
+    /**
+     * 异步发送消息已读回执
+     * @param msgId 消息ID
+     * @return CompletableFuture
+     */
+    CompletableFuture<Void> sendReadAckAsync(long msgId);
+
     ClientState.State getState();
 
     ClientConfigurationData.Auth getAuth();

--- a/cim-client-sdk/src/main/java/com/crossoverjie/cim/client/sdk/impl/ClientImpl.java
+++ b/cim-client-sdk/src/main/java/com/crossoverjie/cim/client/sdk/impl/ClientImpl.java
@@ -8,6 +8,7 @@ import com.crossoverjie.cim.client.sdk.FetchOfflineMsgJob;
 import com.crossoverjie.cim.client.sdk.ReConnectManager;
 import com.crossoverjie.cim.client.sdk.RouteManager;
 import com.crossoverjie.cim.client.sdk.io.CIMClientHandleInitializer;
+import com.crossoverjie.cim.common.constant.Constants;
 import com.crossoverjie.cim.common.data.construct.RingBufferWheel;
 import com.crossoverjie.cim.common.exception.CIMException;
 import com.crossoverjie.cim.common.kit.HeartBeatHandler;
@@ -280,6 +281,34 @@ public class ClientImpl extends ClientState implements Client {
     public CompletableFuture<Void> sendGroupAsync(String msg) {
         // TODO: 2024/9/12 return messageId
         return this.routeManager.sendGroupMsg(new ChatReqVO(this.conf.getAuth().getUserId(), msg, null));
+    }
+
+    @Override
+    public CompletableFuture<Void> sendReadAckAsync(long msgId) {
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        
+        if (channel == null || !channel.isActive()) {
+            future.completeExceptionally(new IllegalStateException("Channel is not active"));
+            return future;
+        }
+
+        Request readAckRequest = Request.newBuilder()
+                .setRequestId(this.conf.getAuth().getUserId())
+                .setCmd(BaseCommand.MESSAGE_READ_ACK)
+                .putProperties(Constants.MetaKey.MSG_ID, String.valueOf(msgId))
+                .build();
+
+        channel.writeAndFlush(readAckRequest).addListener((ChannelFutureListener) channelFuture -> {
+            if (channelFuture.isSuccess()) {
+                log.info("Send read ack success: msgId={}", msgId);
+                future.complete(null);
+            } else {
+                log.error("Send read ack failed: msgId={}", msgId, channelFuture.cause());
+                future.completeExceptionally(channelFuture.cause());
+            }
+        });
+
+        return future;
     }
 
     @Override

--- a/cim-client-sdk/src/main/java/com/crossoverjie/cim/client/sdk/io/CIMClientHandle.java
+++ b/cim-client-sdk/src/main/java/com/crossoverjie/cim/client/sdk/io/CIMClientHandle.java
@@ -62,6 +62,12 @@ public class CIMClientHandle extends SimpleChannelInboundHandler<Response> {
         if (msg.getCmd() == BaseCommand.PING) {
             ClientImpl.getClient().getConf().getEvent().debug("received ping from server");
             NettyAttrUtil.updateReaderTime(ctx.channel(), System.currentTimeMillis());
+            return;
+        }
+
+        if (msg.getCmd() == BaseCommand.MESSAGE_READ_STATUS) {
+            handleReadStatusUpdate(msg);
+            return;
         }
 
         if (msg.getCmd() != BaseCommand.PING) {
@@ -85,6 +91,47 @@ public class CIMClientHandle extends SimpleChannelInboundHandler<Response> {
             });
         }
 
+    }
+
+    private void handleReadStatusUpdate(Response msg) {
+        Map<String, String> properties = msg.getPropertiesMap();
+        String msgIdStr = properties.get(Constants.MetaKey.MSG_ID);
+        String readUserIdStr = properties.get(Constants.MetaKey.READ_USER_ID);
+        String readUserName = properties.get(Constants.MetaKey.READ_USER_NAME);
+        String readTimestampStr = properties.get(Constants.MetaKey.READ_TIMESTAMP);
+
+        if (msgIdStr == null || readUserIdStr == null) {
+            log.warn("MESSAGE_READ_STATUS received but missing required properties");
+            return;
+        }
+
+        try {
+            long msgId = Long.parseLong(msgIdStr);
+            long readUserId = Long.parseLong(readUserIdStr);
+            long readTimestamp = readTimestampStr != null ? Long.parseLong(readTimestampStr) : System.currentTimeMillis();
+
+            String receiveUserId = properties.get(Constants.MetaKey.RECEIVE_USER_ID);
+            if (receiveUserId == null) {
+                log.warn("MESSAGE_READ_STATUS received but missing receiveUserId");
+                return;
+            }
+
+            ClientImpl client = ClientImpl.getClientMap().get(Long.valueOf(receiveUserId));
+            if (client == null) {
+                log.error("client not found for userId: {}", receiveUserId);
+                return;
+            }
+
+            client.getConf().getCallbackThreadPool().execute(() -> {
+                MessageListener messageListener = client.getConf().getMessageListener();
+                messageListener.onReadStatusUpdate(client, msgId, readUserId, readUserName, readTimestamp);
+                log.info("Read status update callback executed: msgId={}, readUserId={}, readUserName={}",
+                        msgId, readUserId, readUserName);
+            });
+
+        } catch (NumberFormatException e) {
+            log.error("Failed to parse MESSAGE_READ_STATUS properties", e);
+        }
     }
 
     @Override

--- a/cim-client-sdk/src/main/java/com/crossoverjie/cim/client/sdk/io/MessageListener.java
+++ b/cim-client-sdk/src/main/java/com/crossoverjie/cim/client/sdk/io/MessageListener.java
@@ -11,4 +11,15 @@ public interface MessageListener {
      * @param msg        msgs
      */
     void received(Client client, Map<String, String> properties, String msg);
+
+    /**
+     * 消息已读状态更新回调
+     * @param client client
+     * @param msgId 消息ID
+     * @param readUserId 已读用户ID
+     * @param readUserName 已读用户名
+     * @param readTimestamp 已读时间戳
+     */
+    default void onReadStatusUpdate(Client client, long msgId, long readUserId, String readUserName, long readTimestamp) {
+    }
 }

--- a/cim-common/src/main/java/com/crossoverjie/cim/common/constant/Constants.java
+++ b/cim-common/src/main/java/com/crossoverjie/cim/common/constant/Constants.java
@@ -26,6 +26,11 @@ public class Constants {
         public static final String SEND_USER_NAME = "sendUserName";
         public static final String RECEIVE_USER_ID = "receiveUserId";
         public static final String RECEIVE_USER_NAME = "receiveUserName";
+        public static final String MSG_ID = "msgId";
+        public static final String GROUP_MEMBER_COUNT = "groupMemberCount";
+        public static final String READ_USER_ID = "readUserId";
+        public static final String READ_USER_NAME = "readUserName";
+        public static final String READ_TIMESTAMP = "readTimestamp";
     }
 
     //从数据库读取离线消息的每次获取量

--- a/cim-common/src/main/proto/cim.proto
+++ b/cim-common/src/main/proto/cim.proto
@@ -24,4 +24,6 @@ enum BaseCommand{
   MESSAGE = 1;
   PING = 2;
   OFFLINE = 3;
+  MESSAGE_READ_ACK = 4;
+  MESSAGE_READ_STATUS = 5;
 }

--- a/cim-forward-route/src/main/java/com/crossoverjie/cim/route/config/BeanConfig.java
+++ b/cim-forward-route/src/main/java/com/crossoverjie/cim/route/config/BeanConfig.java
@@ -21,6 +21,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 import java.lang.reflect.Method;
@@ -138,5 +139,12 @@ public class BeanConfig {
     @Bean
     public SnowflakeIdWorker snowflakeIdWorker() {
         return new SnowflakeIdWorker();
+    }
+
+    @Bean
+    public RedisMessageListenerContainer redisMessageListenerContainer(RedisConnectionFactory connectionFactory) {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
+        return container;
     }
 }

--- a/cim-forward-route/src/main/java/com/crossoverjie/cim/route/constant/Constant.java
+++ b/cim-forward-route/src/main/java/com/crossoverjie/cim/route/constant/Constant.java
@@ -25,6 +25,16 @@ public final class Constant {
      */
     public static final String LOGIN_STATUS_PREFIX = "login-status";
 
+    /**
+     * 消息已读状态前缀
+     */
+    public static final String MSG_READ_PREFIX = "cim-msg-read:";
+
+    /**
+     * 消息已读状态同步频道
+     */
+    public static final String MSG_READ_SYNC_CHANNEL = "cim-msg-read-sync-channel";
+
 
     public static final class OfflineStoreMode {
         /**

--- a/cim-forward-route/src/main/java/com/crossoverjie/cim/route/controller/RouteController.java
+++ b/cim-forward-route/src/main/java/com/crossoverjie/cim/route/controller/RouteController.java
@@ -1,5 +1,6 @@
 package com.crossoverjie.cim.route.controller;
 
+import com.crossoverjie.cim.common.constant.Constants;
 import com.crossoverjie.cim.common.enums.StatusEnum;
 import com.crossoverjie.cim.common.exception.CIMException;
 import com.crossoverjie.cim.common.metastore.MetaStore;
@@ -9,21 +10,27 @@ import com.crossoverjie.cim.common.res.BaseResponse;
 import com.crossoverjie.cim.common.res.NULLBody;
 import com.crossoverjie.cim.common.route.algorithm.RouteHandle;
 import com.crossoverjie.cim.common.util.RouteInfoParseUtil;
+import com.crossoverjie.cim.common.util.SnowflakeIdWorker;
 import com.crossoverjie.cim.route.api.RouteApi;
 import com.crossoverjie.cim.route.api.vo.req.ChatReqVO;
 import com.crossoverjie.cim.route.api.vo.req.LoginReqVO;
+import com.crossoverjie.cim.route.api.vo.req.MsgReadAckReqVO;
 import com.crossoverjie.cim.route.api.vo.req.OfflineMsgReqVO;
 import com.crossoverjie.cim.route.api.vo.req.P2PReqVO;
 import com.crossoverjie.cim.route.api.vo.req.RegisterInfoReqVO;
 import com.crossoverjie.cim.route.api.vo.res.CIMServerResVO;
+import com.crossoverjie.cim.route.api.vo.res.MsgReadStatusResVO;
 import com.crossoverjie.cim.route.api.vo.res.RegisterInfoResVO;
 import com.crossoverjie.cim.route.service.AccountService;
 import com.crossoverjie.cim.route.service.CommonBizService;
+import com.crossoverjie.cim.route.service.MsgMetadataService;
+import com.crossoverjie.cim.route.service.MsgReadService;
 import com.crossoverjie.cim.route.service.OfflineMsgService;
 import com.crossoverjie.cim.route.service.UserInfoCacheService;
 import com.crossoverjie.cim.server.api.ServerApi;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.annotation.Resource;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -70,6 +77,15 @@ public class RouteController implements RouteApi {
     @Resource
     private OfflineMsgService offlineMsgService;
 
+    @Resource
+    private SnowflakeIdWorker snowflakeIdWorker;
+
+    @Resource
+    private MsgMetadataService msgMetadataService;
+
+    @Resource
+    private MsgReadService msgReadService;
+
 
     @Operation(summary = "群聊 API")
     @RequestMapping(value = "groupRoute", method = RequestMethod.POST)
@@ -81,6 +97,16 @@ public class RouteController implements RouteApi {
         log.info("msg=[{}]", groupReqVO.toString());
 
         Map<Long, CIMServerResVO> serverResVoMap = accountService.loadRouteRelated();
+        
+        long msgId = snowflakeIdWorker.nextId();
+        int groupMemberCount = serverResVoMap.size() - 1;
+        
+        msgMetadataService.saveMsgSender(msgId, groupReqVO.getUserId());
+        
+        Map<String, String> extraProperties = new HashMap<>();
+        extraProperties.put(Constants.MetaKey.MSG_ID, String.valueOf(msgId));
+        extraProperties.put(Constants.MetaKey.GROUP_MEMBER_COUNT, String.valueOf(groupMemberCount));
+        
         for (Map.Entry<Long, CIMServerResVO> cimServerResVoEntry : serverResVoMap.entrySet()) {
             Long userId = cimServerResVoEntry.getKey();
             CIMServerResVO cimServerResVO = cimServerResVoEntry.getValue();
@@ -93,7 +119,7 @@ public class RouteController implements RouteApi {
 
             // Push message
             ChatReqVO chatVO = new ChatReqVO(userId, groupReqVO.getMsg(), null);
-            accountService.pushMsg(cimServerResVO, groupReqVO.getUserId(), chatVO);
+            accountService.pushMsg(cimServerResVO, groupReqVO.getUserId(), chatVO, extraProperties);
 
         }
 
@@ -261,6 +287,104 @@ public class RouteController implements RouteApi {
             res.setCode(e.getErrorCode());
             res.setMessage(e.getErrorMessage());
         }
+        return res;
+    }
+
+    @Operation(summary = "消息已读回执")
+    @RequestMapping(value = "msgReadAck", method = RequestMethod.POST)
+    @ResponseBody()
+    @Override
+    public BaseResponse<NULLBody> msgReadAck(@RequestBody MsgReadAckReqVO msgReadAckReqVO) {
+        BaseResponse<NULLBody> res = new BaseResponse();
+
+        log.info("msgReadAck: msgId={}, userId={}", msgReadAckReqVO.getMsgId(), msgReadAckReqVO.getUserId());
+
+        Long sendUserId = msgMetadataService.getMsgSender(msgReadAckReqVO.getMsgId());
+        if (sendUserId == null) {
+            log.warn("Message sender not found for msgId={}", msgReadAckReqVO.getMsgId());
+            res.setCode(StatusEnum.SUCCESS.getCode());
+            res.setMessage(StatusEnum.SUCCESS.getMessage());
+            return res;
+        }
+
+        Optional<CIMUserInfo> readUserInfo = userInfoCacheService.loadUserInfoByUserId(msgReadAckReqVO.getUserId());
+        String readUserName = readUserInfo.map(CIMUserInfo::getUserName).orElse(String.valueOf(msgReadAckReqVO.getUserId()));
+
+        msgReadService.markAsRead(msgReadAckReqVO.getMsgId(), msgReadAckReqVO.getUserId(), readUserName);
+
+        if (!sendUserId.equals(msgReadAckReqVO.getUserId())) {
+            Optional<CIMServerResVO> sendUserServer = accountService.loadRouteRelatedByUserId(sendUserId);
+            sendUserServer.ifPresent(cimServerResVO -> {
+                Optional<CIMUserInfo> sendUserInfo = userInfoCacheService.loadUserInfoByUserId(sendUserId);
+                sendUserInfo.ifPresent(sendInfo -> {
+                    String url = "http://" + cimServerResVO.getIp() + ":" + cimServerResVO.getHttpPort();
+                    
+                    Map<String, String> properties = new HashMap<>();
+                    properties.put(Constants.MetaKey.MSG_ID, String.valueOf(msgReadAckReqVO.getMsgId()));
+                    properties.put(Constants.MetaKey.READ_USER_ID, String.valueOf(msgReadAckReqVO.getUserId()));
+                    properties.put(Constants.MetaKey.READ_USER_NAME, readUserName);
+                    properties.put(Constants.MetaKey.READ_TIMESTAMP, String.valueOf(System.currentTimeMillis()));
+
+                    try {
+                        com.crossoverjie.cim.server.api.vo.req.SendMsgReqVO vo =
+                                new com.crossoverjie.cim.server.api.vo.req.SendMsgReqVO(
+                                        null, 
+                                        sendUserId, 
+                                        null, 
+                                        com.crossoverjie.cim.common.protocol.BaseCommand.MESSAGE_READ_STATUS
+                                );
+                        vo.setProperties(properties);
+                        serverApi.sendMsg(vo, url);
+                        log.info("Pushed read status to sender: msgId={}, sendUserId={}, readUserId={}",
+                                msgReadAckReqVO.getMsgId(), sendUserId, msgReadAckReqVO.getUserId());
+                    } catch (Exception e) {
+                        log.error("Failed to push read status to sender", e);
+                    }
+                });
+            });
+        }
+
+        res.setCode(StatusEnum.SUCCESS.getCode());
+        res.setMessage(StatusEnum.SUCCESS.getMessage());
+        return res;
+    }
+
+    @Operation(summary = "查询消息已读状态")
+    @RequestMapping(value = "getMsgReadStatus", method = RequestMethod.GET)
+    @ResponseBody()
+    @Override
+    public BaseResponse<MsgReadStatusResVO> getMsgReadStatus(Long msgId) {
+        BaseResponse<MsgReadStatusResVO> res = new BaseResponse<>();
+
+        log.info("getMsgReadStatus: msgId={}", msgId);
+
+        Long sendUserId = msgMetadataService.getMsgSender(msgId);
+        if (sendUserId == null) {
+            log.warn("Message not found for msgId={}", msgId);
+            res.setCode(StatusEnum.SUCCESS.getCode());
+            res.setMessage(StatusEnum.SUCCESS.getMessage());
+            res.setDataBody(MsgReadStatusResVO.builder()
+                    .msgId(msgId)
+                    .readCount(0L)
+                    .readUsers(new java.util.HashMap<>())
+                    .build());
+            return res;
+        }
+
+        Map<Long, String> readUsers = msgReadService.getReadUsers(msgId);
+        long readCount = msgReadService.getReadCount(msgId);
+
+        MsgReadStatusResVO statusResVO = MsgReadStatusResVO.builder()
+                .msgId(msgId)
+                .readCount(readCount)
+                .readUsers(readUsers)
+                .build();
+
+        res.setCode(StatusEnum.SUCCESS.getCode());
+        res.setMessage(StatusEnum.SUCCESS.getMessage());
+        res.setDataBody(statusResVO);
+
+        log.info("getMsgReadStatus result: msgId={}, readCount={}", msgId, readCount);
         return res;
     }
 }

--- a/cim-forward-route/src/main/java/com/crossoverjie/cim/route/service/AccountService.java
+++ b/cim-forward-route/src/main/java/com/crossoverjie/cim/route/service/AccountService.java
@@ -66,6 +66,16 @@ public interface AccountService {
     void pushMsg(CIMServerResVO cimServerResVO, long sendUserId, ChatReqVO groupReqVO);
 
     /**
+     * 推送消息（带额外属性）
+     * @param cimServerResVO
+     * @param groupReqVO 消息
+     * @param sendUserId 发送者的ID
+     * @param extraProperties 额外的消息属性
+     * @throws Exception
+     */
+    void pushMsg(CIMServerResVO cimServerResVO, long sendUserId, ChatReqVO groupReqVO, Map<String, String> extraProperties);
+
+    /**
      * 用户下线
      * @param userId 下线用户ID
      * @throws Exception

--- a/cim-forward-route/src/main/java/com/crossoverjie/cim/route/service/MsgMetadataService.java
+++ b/cim-forward-route/src/main/java/com/crossoverjie/cim/route/service/MsgMetadataService.java
@@ -1,0 +1,32 @@
+package com.crossoverjie.cim.route.service;
+
+/**
+ * Function: 消息元数据服务
+ * 用于存储消息ID与发送者ID的映射关系
+ *
+ * @author crossoverJie
+ * Date: 2026/05/02
+ * @since JDK 1.8
+ */
+public interface MsgMetadataService {
+
+    /**
+     * 保存消息发送者信息
+     * @param msgId 消息ID
+     * @param sendUserId 发送者用户ID
+     */
+    void saveMsgSender(long msgId, long sendUserId);
+
+    /**
+     * 获取消息发送者ID
+     * @param msgId 消息ID
+     * @return 发送者用户ID，如果不存在则返回 null
+     */
+    Long getMsgSender(long msgId);
+
+    /**
+     * 删除消息元数据
+     * @param msgId 消息ID
+     */
+    void removeMsgMetadata(long msgId);
+}

--- a/cim-forward-route/src/main/java/com/crossoverjie/cim/route/service/MsgReadService.java
+++ b/cim-forward-route/src/main/java/com/crossoverjie/cim/route/service/MsgReadService.java
@@ -1,0 +1,59 @@
+package com.crossoverjie.cim.route.service;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Function: 消息已读状态服务
+ *
+ * @author crossoverJie
+ * Date: 2026/05/02
+ * @since JDK 1.8
+ */
+public interface MsgReadService {
+
+    /**
+     * 记录用户已读某条消息
+     * @param msgId 消息ID
+     * @param userId 用户ID
+     * @param userName 用户名
+     */
+    void markAsRead(long msgId, long userId, String userName);
+
+    /**
+     * 查询用户是否已读某条消息
+     * @param msgId 消息ID
+     * @param userId 用户ID
+     * @return 是否已读
+     */
+    boolean isRead(long msgId, long userId);
+
+    /**
+     * 获取消息的已读用户列表
+     * @param msgId 消息ID
+     * @return 已读用户ID集合（userId -> userName）
+     */
+    Map<Long, String> getReadUsers(long msgId);
+
+    /**
+     * 获取消息的已读用户数量
+     * @param msgId 消息ID
+     * @return 已读用户数量
+     */
+    long getReadCount(long msgId);
+
+    /**
+     * 删除消息的已读状态
+     * @param msgId 消息ID
+     */
+    void removeMsgReadStatus(long msgId);
+
+    /**
+     * 同步已读状态到其他服务器（集群环境）
+     * @param msgId 消息ID
+     * @param userId 用户ID
+     * @param userName 用户名
+     * @param timestamp 时间戳
+     */
+    void syncReadStatusToCluster(long msgId, long userId, String userName, long timestamp);
+}

--- a/cim-forward-route/src/main/java/com/crossoverjie/cim/route/service/impl/AccountServiceRedisImpl.java
+++ b/cim-forward-route/src/main/java/com/crossoverjie/cim/route/service/impl/AccountServiceRedisImpl.java
@@ -152,17 +152,28 @@ public class AccountServiceRedisImpl implements AccountService {
 
     @Override
     public void pushMsg(CIMServerResVO cimServerResVO, long sendUserId, ChatReqVO chatReqVO) {
+        pushMsg(cimServerResVO, sendUserId, chatReqVO, null);
+    }
+
+    @Override
+    public void pushMsg(CIMServerResVO cimServerResVO, long sendUserId, ChatReqVO chatReqVO, Map<String, String> extraProperties) {
         Optional<CIMUserInfo> cimUserInfo = userInfoCacheService.loadUserInfoByUserId(sendUserId);
 
         cimUserInfo.ifPresent(sendUserInfo -> {
             String url = "http://" + cimServerResVO.getIp() + ":" + cimServerResVO.getHttpPort();
             SendMsgReqVO vo =
                     new SendMsgReqVO(chatReqVO.getMsg(), chatReqVO.getUserId(), chatReqVO.getBatchMsg(), BaseCommand.MESSAGE);
-            vo.setProperties(Map.of(
-                    Constants.MetaKey.SEND_USER_ID, String.valueOf(sendUserId),
-                    Constants.MetaKey.SEND_USER_NAME, sendUserInfo.getUserName(),
-                    Constants.MetaKey.RECEIVE_USER_ID, String.valueOf(chatReqVO.getUserId()))
-            );
+            
+            Map<String, String> properties = new HashMap<>();
+            properties.put(Constants.MetaKey.SEND_USER_ID, String.valueOf(sendUserId));
+            properties.put(Constants.MetaKey.SEND_USER_NAME, sendUserInfo.getUserName());
+            properties.put(Constants.MetaKey.RECEIVE_USER_ID, String.valueOf(chatReqVO.getUserId()));
+            
+            if (extraProperties != null && !extraProperties.isEmpty()) {
+                properties.putAll(extraProperties);
+            }
+            
+            vo.setProperties(properties);
             serverApi.sendMsg(vo, url);
 
         });

--- a/cim-forward-route/src/main/java/com/crossoverjie/cim/route/service/impl/MsgMetadataServiceRedisImpl.java
+++ b/cim-forward-route/src/main/java/com/crossoverjie/cim/route/service/impl/MsgMetadataServiceRedisImpl.java
@@ -1,0 +1,58 @@
+package com.crossoverjie.cim.route.service.impl;
+
+import com.crossoverjie.cim.route.constant.Constant;
+import com.crossoverjie.cim.route.service.MsgMetadataService;
+import jakarta.annotation.Resource;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Function: 消息元数据服务 Redis 实现
+ *
+ * @author crossoverJie
+ * Date: 2026/05/02
+ * @since JDK 1.8
+ */
+@Slf4j
+@Service
+public class MsgMetadataServiceRedisImpl implements MsgMetadataService {
+
+    @Resource
+    private RedisTemplate<String, String> redisTemplate;
+
+    private static final String MSG_METADATA_PREFIX = "cim-msg-meta:";
+    private static final long MSG_METADATA_EXPIRE_DAYS = 7;
+
+    @Override
+    public void saveMsgSender(long msgId, long sendUserId) {
+        String key = MSG_METADATA_PREFIX + msgId;
+        redisTemplate.opsForValue().set(key, String.valueOf(sendUserId));
+        redisTemplate.expire(key, MSG_METADATA_EXPIRE_DAYS, TimeUnit.DAYS);
+        log.info("Saved message metadata: msgId={}, sendUserId={}", msgId, sendUserId);
+    }
+
+    @Override
+    public Long getMsgSender(long msgId) {
+        String key = MSG_METADATA_PREFIX + msgId;
+        String value = redisTemplate.opsForValue().get(key);
+        if (value == null) {
+            return null;
+        }
+        try {
+            return Long.parseLong(value);
+        } catch (NumberFormatException e) {
+            log.error("Failed to parse sendUserId for msgId={}", msgId, e);
+            return null;
+        }
+    }
+
+    @Override
+    public void removeMsgMetadata(long msgId) {
+        String key = MSG_METADATA_PREFIX + msgId;
+        redisTemplate.delete(key);
+        log.info("Removed message metadata: msgId={}", msgId);
+    }
+}

--- a/cim-forward-route/src/main/java/com/crossoverjie/cim/route/service/impl/MsgReadServiceRedisImpl.java
+++ b/cim-forward-route/src/main/java/com/crossoverjie/cim/route/service/impl/MsgReadServiceRedisImpl.java
@@ -1,0 +1,148 @@
+package com.crossoverjie.cim.route.service.impl;
+
+import com.crossoverjie.cim.route.constant.Constant;
+import com.crossoverjie.cim.route.service.MsgReadService;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.Resource;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.PatternTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.stereotype.Service;
+
+/**
+ * Function: 消息已读状态服务 Redis 实现
+ *
+ * @author crossoverJie
+ * Date: 2026/05/02
+ * @since JDK 1.8
+ */
+@Slf4j
+@Service
+public class MsgReadServiceRedisImpl implements MsgReadService {
+
+    @Resource
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Resource
+    private RedisMessageListenerContainer redisMessageListenerContainer;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @PostConstruct
+    public void init() {
+        redisMessageListenerContainer.addMessageListener(new MessageListener() {
+            @Override
+            public void onMessage(Message message, byte[] pattern) {
+                try {
+                    String channel = new String(message.getChannel());
+                    String body = new String(message.getBody());
+                    log.info("Received message from channel [{}]: {}", channel, body);
+                    
+                    ReadStatusSyncMessage syncMessage = objectMapper.readValue(body, ReadStatusSyncMessage.class);
+                    
+                    String key = Constant.MSG_READ_PREFIX + syncMessage.getMsgId();
+                    String value = syncMessage.getUserName() + ":" + syncMessage.getTimestamp();
+                    redisTemplate.opsForHash().put(key, String.valueOf(syncMessage.getUserId()), value);
+                    
+                    log.info("Synced read status: msgId={}, userId={}, userName={}", 
+                            syncMessage.getMsgId(), syncMessage.getUserId(), syncMessage.getUserName());
+                } catch (JsonProcessingException e) {
+                    log.error("Failed to parse sync message", e);
+                }
+            }
+        }, new PatternTopic(Constant.MSG_READ_SYNC_CHANNEL));
+        
+        log.info("MsgReadServiceRedisImpl initialized, listening on channel: {}", Constant.MSG_READ_SYNC_CHANNEL);
+    }
+
+    @Override
+    public void markAsRead(long msgId, long userId, String userName) {
+        String key = Constant.MSG_READ_PREFIX + msgId;
+        long timestamp = System.currentTimeMillis();
+        String value = userName + ":" + timestamp;
+        
+        redisTemplate.opsForHash().put(key, String.valueOf(userId), value);
+        
+        log.info("Marked message as read: msgId={}, userId={}, userName={}, timestamp={}", 
+                msgId, userId, userName, timestamp);
+        
+        syncReadStatusToCluster(msgId, userId, userName, timestamp);
+    }
+
+    @Override
+    public boolean isRead(long msgId, long userId) {
+        String key = Constant.MSG_READ_PREFIX + msgId;
+        return redisTemplate.opsForHash().hasKey(key, String.valueOf(userId));
+    }
+
+    @Override
+    public Map<Long, String> getReadUsers(long msgId) {
+        String key = Constant.MSG_READ_PREFIX + msgId;
+        Map<Object, Object> entries = redisTemplate.opsForHash().entries(key);
+        
+        Map<Long, String> result = new HashMap<>();
+        for (Map.Entry<Object, Object> entry : entries.entrySet()) {
+            long userId = Long.parseLong((String) entry.getKey());
+            String value = (String) entry.getValue();
+            String userName = value.split(":")[0];
+            result.put(userId, userName);
+        }
+        
+        return result;
+    }
+
+    @Override
+    public long getReadCount(long msgId) {
+        String key = Constant.MSG_READ_PREFIX + msgId;
+        return redisTemplate.opsForHash().size(key);
+    }
+
+    @Override
+    public void removeMsgReadStatus(long msgId) {
+        String key = Constant.MSG_READ_PREFIX + msgId;
+        redisTemplate.delete(key);
+        log.info("Removed message read status: msgId={}", msgId);
+    }
+
+    @Override
+    public void syncReadStatusToCluster(long msgId, long userId, String userName, long timestamp) {
+        try {
+            ReadStatusSyncMessage syncMessage = ReadStatusSyncMessage.builder()
+                    .msgId(msgId)
+                    .userId(userId)
+                    .userName(userName)
+                    .timestamp(timestamp)
+                    .build();
+            
+            String message = objectMapper.writeValueAsString(syncMessage);
+            redisTemplate.convertAndSend(Constant.MSG_READ_SYNC_CHANNEL, message);
+            
+            log.info("Synced read status to cluster: msgId={}, userId={}", msgId, userId);
+        } catch (JsonProcessingException e) {
+            log.error("Failed to sync read status to cluster", e);
+        }
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ReadStatusSyncMessage {
+        private long msgId;
+        private long userId;
+        private String userName;
+        private long timestamp;
+    }
+}

--- a/cim-rout-api/src/main/java/com/crossoverjie/cim/route/api/RouteApi.java
+++ b/cim-rout-api/src/main/java/com/crossoverjie/cim/route/api/RouteApi.java
@@ -6,10 +6,12 @@ import com.crossoverjie.cim.common.res.BaseResponse;
 import com.crossoverjie.cim.common.res.NULLBody;
 import com.crossoverjie.cim.route.api.vo.req.ChatReqVO;
 import com.crossoverjie.cim.route.api.vo.req.LoginReqVO;
+import com.crossoverjie.cim.route.api.vo.req.MsgReadAckReqVO;
 import com.crossoverjie.cim.route.api.vo.req.OfflineMsgReqVO;
 import com.crossoverjie.cim.route.api.vo.req.P2PReqVO;
 import com.crossoverjie.cim.route.api.vo.req.RegisterInfoReqVO;
 import com.crossoverjie.cim.route.api.vo.res.CIMServerResVO;
+import com.crossoverjie.cim.route.api.vo.res.MsgReadStatusResVO;
 import com.crossoverjie.cim.route.api.vo.res.RegisterInfoResVO;
 
 import java.util.Set;
@@ -78,5 +80,23 @@ public interface RouteApi {
 
 
     BaseResponse<NULLBody> fetchOfflineMsgs(OfflineMsgReqVO offlineMsgReqVO);
+
+    /**
+     * 消息已读回执
+     * @param msgReadAckReqVO 已读回执请求
+     * @return
+     * @throws Exception
+     */
+    BaseResponse<NULLBody> msgReadAck(MsgReadAckReqVO msgReadAckReqVO);
+
+    /**
+     * 查询消息已读状态
+     * @param msgId 消息ID
+     * @return 消息已读状态
+     * @throws Exception
+     */
+    @Request(method = Request.GET)
+    BaseResponse<MsgReadStatusResVO> getMsgReadStatus(Long msgId);
+
     // TODO: 2024/8/19  Get cache server & metastore server
 }

--- a/cim-rout-api/src/main/java/com/crossoverjie/cim/route/api/vo/req/MsgReadAckReqVO.java
+++ b/cim-rout-api/src/main/java/com/crossoverjie/cim/route/api/vo/req/MsgReadAckReqVO.java
@@ -1,0 +1,37 @@
+package com.crossoverjie.cim.route.api.vo.req;
+
+import com.crossoverjie.cim.common.req.BaseRequest;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * Function: 消息已读回执请求 VO
+ *
+ * @author crossoverJie
+ * Date: 2026/05/02
+ * @since JDK 1.8
+ */
+@EqualsAndHashCode(callSuper = true)
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class MsgReadAckReqVO extends BaseRequest {
+
+    @NotNull(message = "msgId 不能为空")
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED, description = "消息ID", example = "1234567890")
+    private Long msgId;
+
+    @NotNull(message = "userId 不能为空")
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED, description = "已读用户ID", example = "1545574049323")
+    private Long userId;
+
+    @Schema(description = "已读用户名", example = "user1")
+    private String userName;
+
+    @Schema(description = "已读时间戳", example = "1622505600000")
+    private Long timestamp;
+}

--- a/cim-rout-api/src/main/java/com/crossoverjie/cim/route/api/vo/res/MsgReadStatusResVO.java
+++ b/cim-rout-api/src/main/java/com/crossoverjie/cim/route/api/vo/res/MsgReadStatusResVO.java
@@ -1,0 +1,37 @@
+package com.crossoverjie.cim.route.api.vo.res;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Function: 消息已读状态响应 VO
+ *
+ * @author crossoverJie
+ * Date: 2026/05/02
+ * @since JDK 1.8
+ */
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class MsgReadStatusResVO {
+
+    @Schema(description = "消息ID", example = "1234567890")
+    private Long msgId;
+
+    @Schema(description = "已读用户数量", example = "3")
+    private Long readCount;
+
+    @Schema(description = "群聊成员总数", example = "5")
+    private Integer totalMemberCount;
+
+    @Schema(description = "已读用户列表 (userId -> userName)")
+    private Map<Long, String> readUsers;
+
+    @Schema(description = "未读用户数量", example = "2")
+    private Integer unreadCount;
+}

--- a/cim-server/src/main/java/com/crossoverjie/cim/server/handle/CIMServerHandle.java
+++ b/cim-server/src/main/java/com/crossoverjie/cim/server/handle/CIMServerHandle.java
@@ -1,11 +1,14 @@
 package com.crossoverjie.cim.server.handle;
 
+import com.crossoverjie.cim.common.constant.Constants;
 import com.crossoverjie.cim.common.exception.CIMException;
 import com.crossoverjie.cim.common.kit.HeartBeatHandler;
 import com.crossoverjie.cim.common.pojo.CIMUserInfo;
 import com.crossoverjie.cim.common.protocol.BaseCommand;
 import com.crossoverjie.cim.common.protocol.Request;
 import com.crossoverjie.cim.common.util.NettyAttrUtil;
+import com.crossoverjie.cim.route.api.RouteApi;
+import com.crossoverjie.cim.route.api.vo.req.MsgReadAckReqVO;
 import com.crossoverjie.cim.server.kit.RouteHandler;
 import com.crossoverjie.cim.server.kit.ServerHeartBeatHandlerImpl;
 import com.crossoverjie.cim.server.util.SessionSocketHolder;
@@ -17,6 +20,7 @@ import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.timeout.IdleState;
 import io.netty.handler.timeout.IdleStateEvent;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -94,6 +98,42 @@ public class CIMServerHandle extends SimpleChannelInboundHandler<Request> {
             });
         }
 
+        //消息已读回执
+        if (msg.getCmd() == BaseCommand.MESSAGE_READ_ACK) {
+            handleMsgReadAck(msg);
+        }
+
+    }
+
+    private void handleMsgReadAck(Request msg) {
+        Map<String, String> properties = msg.getPropertiesMap();
+        String msgIdStr = properties.get(Constants.MetaKey.MSG_ID);
+        
+        if (msgIdStr == null || msgIdStr.isEmpty()) {
+            log.warn("MESSAGE_READ_ACK received but msgId is missing");
+            return;
+        }
+
+        try {
+            long msgId = Long.parseLong(msgIdStr);
+            long userId = msg.getRequestId();
+            
+            log.info("Processing MESSAGE_READ_ACK: msgId={}, userId={}", msgId, userId);
+            
+            RouteApi routeApi = SpringBeanFactory.getBean(RouteApi.class);
+            MsgReadAckReqVO reqVO = new MsgReadAckReqVO();
+            reqVO.setMsgId(msgId);
+            reqVO.setUserId(userId);
+            reqVO.setTimestamp(System.currentTimeMillis());
+            
+            routeApi.msgReadAck(reqVO);
+            
+            log.info("MESSAGE_READ_ACK processed successfully: msgId={}, userId={}", msgId, userId);
+        } catch (NumberFormatException e) {
+            log.error("Invalid msgId format: {}", msgIdStr, e);
+        } catch (Exception e) {
+            log.error("Failed to process MESSAGE_READ_ACK", e);
+        }
     }
 
 


### PR DESCRIPTION
新增消息已读回执和状态同步功能，包括：
1. 在proto中新增MESSAGE_READ_ACK和MESSAGE_READ_STATUS命令
2. 添加消息元数据服务存储消息发送者信息
3. 实现消息已读状态服务记录已读状态
4. 客户端SDK新增已读回执发送接口
5. 服务端处理已读回执并同步状态
6. 提供查询消息已读状态API
7. 支持集群环境下已读状态同步

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added message read receipt support — clients can now send read acknowledgments for received messages
  * Added message read status tracking — servers now track and display which users have read messages, including read counts and user details
  * Enhanced message metadata — messages now include unique identifiers and additional tracking information for read status management
  * New API endpoints to query message read status and record read receipts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->